### PR TITLE
Create device init extensions

### DIFF
--- a/extensions/COREAVI/EGL_COREAVI_device_init.txt
+++ b/extensions/COREAVI/EGL_COREAVI_device_init.txt
@@ -163,7 +163,7 @@ Issues
 
 Revision History
 	
-	Revision 0.5 2025/05/05
+	Revision 0.5 2022/05/05
 	    - Add attributes for object creation maximums.
 		
 	Revision 0.4 2021/10/12

--- a/extensions/COREAVI/EGL_COREAVI_device_init.txt
+++ b/extensions/COREAVI/EGL_COREAVI_device_init.txt
@@ -1,0 +1,182 @@
+Name
+
+	EGL_COREAVI_device_init
+
+Name Strings
+	
+	EGL_EXT_device_init
+	
+Contact
+
+	Nicolas Collin, Core Avionics & Industrial Inc. (nicolas 'dot' collin 'at' coreavi 'dot' com)
+
+Contributors
+	
+	Anirban Basu
+	Daniel Herring, 
+	Ken Wenger 
+
+Status
+
+	Complete
+
+Version
+
+	Last Modified Date: May 5, 2022
+	Revision: 0.5
+
+Number
+
+    EGL Extension #147
+
+Extension Type
+
+    EGL client extension
+
+Dependencies
+
+	Requires EGL 1.0
+	
+	This extension is written against the wording of the EGL 1.4
+	Specification - December 4, 2013, but may be implemented against earlier
+	versions.
+	
+Overview
+
+	This extension provides for a means to execute the EGL API's on 
+	systems lacking native windowing systems. An embedded GPU system 
+	could be a typical example of this. 
+	
+	Traditionally EGL functions rely on the information provided by the 
+	windowing system to create displays and surfaces or to enumerate 
+	available configs. Systems lacking these software stacks can use 
+	the proposed functions to incorporate some basic device and display 
+	management of the GPU and standardize the way to obtain the required
+	information. 
+	
+IP Status
+
+	No known IP claims.
+
+New Procedures and Functions
+
+	EGLDeviceEXT eglInitializeDeviceEXT(EGLAttribKHR *attrib_list);
+
+	EGLBoolean eglDestroyDeviceEXT(EGLDeviceEXT device);
+	
+New Types
+
+	typedef void* EGLDeviceEXT
+
+New Tokens
+
+eglInitializeDeviceEXT can return this to indicate that no valid 
+device object was created. 
+
+	#define EGL_NO_DEVICE_EXT       ((EGLDeviceEXT)0)
+	
+Additions to Chapter 3 of the EGL 1.4 Specification
+(EGL Functions and Errors)
+
+Add the function to section 3.2 Pg 12:
+
+	Applications can choose and initialize an EGL device at the
+	start by calling the function:					
+
+	EGLDeviceEXT eglInitializeDeviceEXT(EGLAttribKHR *attrib_list);  			
+		
+	This function initalizes the EGL device chosen through the device
+	ID attribute in <attrib_list> and generates an internal list of all the
+	supported displays. This list will be used later by eglGetDisplay to
+	provide an appropriate display to the application. Any additional
+	device / display management tasks required to support the EGL API's
+	should be handled here. The function returns an object of type
+	EGLDeviceEXT, which is an abstract representation of a graphics device.
+	All EGL operations for the given device happen on this device object.
+	All attribute names in <attrib list> are immediately followed by the
+	corresponding desired value. The list is terminated with EGL_NONE.
+	Each attribute can either be the device ID attribute, a system
+	attribute or an object creation maximum. The device ID attribute
+	specifies which GPU to initialize, the system attributes pass initialization 
+	parameters affecting the system behavior, and the object creation maximums
+	pass in the maximum number of a certain object type to create. Passing 
+	an invalid attribute or value will cause the function to fail and it 
+	will return EGL_NO_DEVICE_EXT. Passing either an empty attribute list 
+	or a NULL pointer will return a device object representing the first 
+	device in the system initialized with all the default parameters. 
+	However, note that default parameters don't include the shaders attributes.
+	
+	On Failure, eglInitializeDeviceEXT will return EGL_NO_DEVICE_EXT. 
+	
+	Calling this function with the same <attrib_list> multiple times will
+	return the same device object and will have no additional impact.
+	
+Add the function to the end of section 3.2 on pg. 14:
+
+	At the end of all the rendering operations, after terminating all
+	displays relative to a device, and destroying all the associated
+	contexts and surfaces, the said device object can be destroyed by
+	calling:
+
+		EGLBoolean eglDestroyDeviceEXT(EGLDeviceEXT device);
+	
+	This function will destroy the device object 'device' and release
+	all resources held by it. Referring to destroyed device objects 
+	will result in an error.
+	
+	eglDestroyDeviceEXT will return EGL_FALSE on a failure. Failure to
+	destroy a device might be an indication that resources held by the 
+	device were not successfully relinquished and any subsequent Device 
+	re-initialization might fail too. Restarting the entire graphic 
+	sub-system might be the only option in such cases. 
+
+Errors
+
+	eglInitializeDeviceEXT returns EGL_NO_DEVICE_EXT on failure. 
+	
+	eglDestroyDevicesEXT returns EGL_FALSE on failure. 
+
+Sample Code
+
+   None
+
+Conformance Tests
+
+    None
+
+Issues
+
+    1. Why is the attribute list of type EGLAttribKHR ?
+   
+       To allow attributes to pass in 64-bit values like pointers. 
+	 
+    2. Will eglDestroyDevicesEXT() synchronize with the client API's 
+       to wait for all commands to complete before destroying the 
+       device ?
+	
+       No, it is the responsibility of the application to make sure all
+       drawing commands on all contexts have finished and all displays 
+       have been terminated before destroying the device. The 
+       application can use all the synchronization API's at its 
+       disposal to easily ensure that all the tasks on all threads have 
+       completed before calling eglDestroyDevicesEXT. 
+
+Revision History
+	
+	Revision 0.5 2025/05/05
+	    - Add attributes for object creation maximums.
+		
+	Revision 0.4 2021/10/12
+	    - Fixed typos.
+	    - Add device ID attribute.
+
+	Revision 0.3 2020/06/22
+	    - Changed the name of he initialization function. 
+	    - Add more description on attribute types. 
+	    - Change Attribute list to be of type EGLAttribKHR
+		
+	Revision 0.2 2020/06/16
+	    - Improved description based on review comments. 
+		
+	Revision 0.1 2020/06/08
+	    - Initial Draft

--- a/extensions/COREAVI/EGL_COREAVI_device_init_attribute.txt
+++ b/extensions/COREAVI/EGL_COREAVI_device_init_attribute.txt
@@ -1,0 +1,336 @@
+Name
+
+    EGL_COREAVI_device_init_attribute
+
+Name Strings
+    
+    EGL_EXT_device_init_attribute
+    
+Contributors
+
+    Anirban Basu
+    
+Contact
+
+    Nicolas Collin, Core Avionics & Industrial Inc. (nicolas 'dot' collin 'at' coreavi 'dot' com)
+
+Status
+
+    Complete
+
+Version
+
+    Last Modified Date: May 5, 2022
+    Revision: 0.3
+
+Number
+
+    EGL Extension #147
+
+Extension Type
+
+    EGL client extension
+
+Dependencies
+
+    Requires EGL 1.0
+    
+    Requires EGL_EXT_device_init extension
+    
+    
+    This extension is written against the wording of the EGL 1.4
+    Specification - December 4, 2013 as modified by the extension 
+    EGL_EXT_device_init but may be implemented against earlier
+    versions.
+    
+Overview
+
+    This extension proposes the attributes that can be used to 
+    appropriately initialize EGL devices in a system, when passed in the
+    attribute list to the function eglInitializeDeviceEXT() as defined in
+    the EGL_EXT_device_init extension.  
+    
+    Proposed here are seven attributes: the device ID attribute, six
+    system attributes and nineteen object creation maximums.
+    The device ID attribute is used to select a specific GPU device in the
+    system. The system attributes can be used to indicate use of shared
+    memory locations, pass the application name to the driver, pass a
+    potential direct-call interface, as well as informations about the
+    shader programs the application will use in its lifetime. The object
+    creation maximums can be used to set the maximum number of an
+    object type the application can create.
+    
+IP Status
+
+    No known IP claims.
+
+New Procedures and Functions
+
+    None
+    
+New Types
+
+    None
+
+New Tokens
+
+    Accepted as an attribute in the attribute list by the function 
+    eglInitializeDeviceEXT
+
+    #define EGL_DEVICE_INIT_GPU_DEVICE_ID_COREAVI                   0x3465
+    #define EGL_DEVICE_INIT_APP_NAME_COREAVI                        0x3466
+    #define EGL_DEVICE_INIT_SHARED_MEMORY_COREAVI                   0x3467
+    #define EGL_DEVICE_DIRECT_CALL_COREAVI                          0x3468
+    #define EGL_SHADER_PROGRAM_COUNT_COREAVI                        0x3469
+    #define EGL_SHADER_PROGRAM_BINARY_COREAVI                       0x346A
+    #define EGL_SHADER_PROGRAM_SIZE_COREAVI                         0x346B
+    #define EGL_DEVICE_MAX_IMAGES_COREAVI                           0x3500
+    #define EGL_DEVICE_MAX_IMAGE_VIEWS_COREAVI                      0x3501
+    #define EGL_DEVICE_MAX_SEMAPHORES_COREAVI                       0x3502
+    #define EGL_DEVICE_MAX_EVENTS_COREAVI                           0x3503
+    #define EGL_DEVICE_MAX_RENDER_PASSES_COREAVI                    0x3504
+    #define EGL_DEVICE_MAX_PIPELINE_LAYOUTS_COREAVI                 0x3505
+    #define EGL_DEVICE_MAX_GRAPHICS_PIPELINES_COREAVI               0x3506
+    #define EGL_DEVICE_MAX_FRAMEBUFFERS_COREAVI                     0x3507
+    #define EGL_DEVICE_MAX_COMMAND_POOLS_COREAVI                    0x3508
+    #define EGL_DEVICE_MAX_COMMAND_BUFFERS_COREAVI                  0x3509
+    #define EGL_DEVICE_MAX_SWAPCHAINS_KHR_COREAVI                   0x350A
+    #define EGL_DEVICE_MAX_RENDER_PASS_SUBPASSES_COREAVI            0x350B
+    #define EGL_DEVICE_MAX_RENDER_PASS_ATTACHMENTS_COREAVI          0x350C
+    #define EGL_DEVICE_MAX_DESCRIPTOR_SETS_COREAVI                  0x350D
+    #define EGL_DEVICE_MAX_DESCRIPTOR_SET_LAYOUTS_COREAVI           0x350E
+    #define EGL_DEVICE_MAX_DESCRIPTOR_POOLS_COREAVI                 0x350F
+    #define EGL_DEVICE_MAX_DESCRIPTOR_SET_LAYOUT_BINDINGS_COREAVI   0x3510
+    #define EGL_DEVICE_MAX_BUFFERS_COREAVI                          0x3511
+    #define EGL_DEVICE_MAX_SAMPLERS_COREAVI                         0x3512
+    
+Additions to Chapter 3 of the EGL 1.4 Specification
+(EGL Functions and Errors)
+
+Add to section 3.2 Pg 12 in the section describing the function 
+eglInitializeDeviceEXT as specified in the EGL_EXT_device_init extension:
+
+Add the following text & table after the description of the 
+eglInitializeDeviceEXT function. 
+
+    The following table describes the attributes and valid values that 
+    can be passed in via the attrib_list to this function. 
+    
+    +-----------------------------------------------------------+-------------------------------+------------------------------------+-----------------+
+    | Attribute                                                 | Description                   | Value                              | Default Value   |
+    +-----------------------------------------------------------+-------------------------------+------------------------------------+-----------------+
+    | EGL_DEVICE_INIT_GPU_DEVICE_ID_COREAVI                     | This attribute specifies      | Device number using 0 based        | 0               |
+    |                                                           | the device in the graphics    | numbering scheme where '0'         |                 |
+    |                                                           | system to be chosen and initi-| refers to the first device         |                 |
+    |                                                           | alized.                       | and 'n' refers to n+1 th           |                 |
+    |                                                           |                               | device.                            |                 |
+    |                                                           |                               | Value should be between 0          |                 |
+    |                                                           |                               | and n-1 for a system with n        |                 |
+    |                                                           |                               | graphics devices.                  |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_INIT_SHARED_MEMORY_COREAVI                     | This system attribute can be  | EGL_FALSE: No use of shared        | 0               |
+    |                                                           | used to indicate use of share |            memory regions.         |                 |
+    |                                                           | memory regions                | EGL_TRUE: Use shared memory        |                 |
+    |                                                           |                               |           regions.                 |                 |
+    |                                                           |                               |                                    |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_INIT_APP_NAME_COREAVI                          | This system attribute provides| Pointer to a Null terminated       | NULL            |
+    |                                                           | a means to pass an application| string holding the name of         |                 |
+    |                                                           | name to a driver. This inform-| application.                       |                 |
+    |                                                           | ation can be used by drivers  |                                    |                 |
+    |                                                           | to initialize devices in ways |                                    |                 |
+    |                                                           | specific classes of applicati-|                                    |                 |
+    |                                                           | ons.                          |                                    |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_DIRECT_CALL_COREAVI                            | This system attribute provides| Pointer to a Vulkan                | NULL            |
+    |                                                           | a pointer to a structure      | VkDirectCallInterfaceCOREAVI       |                 |
+    |                                                           | defining the direct-call      | structure.                         |                 |
+    |                                                           | interface for the underlying  |                                    |                 |
+    |                                                           | VKCore SC implementation,     |                                    |                 |
+    |                                                           | allowing the application to   |                                    |                 |
+    |                                                           | send commands directly to     |                                    |                 |
+    |                                                           | the GPU without the use of a  |                                    |                 |
+    |                                                           | separate GPU Manager          |                                    |                 |
+    |                                                           | application.                  |                                    |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_SHADER_PROGRAM_COUNT_COREAVI                          | This system attribute         | Number of shader programs.         | 0 (might not be |
+    |                                                           | specifies the total number of | Specifies the number of            | considered as   |
+    |                                                           | shader programs the           | entries in                         | valid by some   |
+    |                                                           | application will use in its   | EGL_SHADER_PROGRAM_SIZE_COREAVI and| implementations)|
+    |                                                           | lifetime.                     | EGL_SHADER_PROGRAM_BINARY_COREAVI  |
+    |                                                           |                               |                                    |                 |
+    | EGL_SHADER_PROGRAM_BINARY_COREAVI                         | This system attribute is used | Array of pointers to each          | NULL (might not |
+    |                                                           | to pass to the driver the     | shader program binary.             | be considered as|
+    |                                                           | binary for each shader program|                                    | valid by some   |
+    |                                                           | the application will use in   |                                    | implementations)|
+    |                                                           | its lifetime.                 |                                    |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_SHADER_PROGRAM_SIZE_COREAVI                           | This system attribute         | Array that stores the size,        | NULL (might not |
+    |                                                           | specifies the size for each   | in bytes, for each shader          | be considered as|
+    |                                                           | shader program binary.        | program binary. Corresponds        | valid by some   |
+    |                                                           |                               | directly to                        | implementations)|
+    |                                                           |                               | EGL_SHADER_PROGRAM_BINARY_COREAVI. |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_IMAGES_COREAVI                             | This attribute specifies      | Maximum number of image objects    | 4096 (might not |
+    |                                                           | the maximum number            | expressed as an unsigned integer.  | be considered as|
+    |                                                           | of images the application     |                                    | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_IMAGE_VIEWS_COREAVI                        | This attribute specifies      | Maximum number of image view       | 4096 (might not |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of image views the application| integer.                           | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_SEMAPHORES_COREAVI                         | This attribute specifies      | Maximum number of semaphore objects| 1024 (might not |
+    |                                                           | the maximum number            | expressed as an unsigned integer.  | be considered as|
+    |                                                           | of semaphores the application |                                    | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_EVENTS_COREAVI                             | This attribute specifies      | Maximum number of event objects    | 4096 (might not |
+    |                                                           | the maximum number            | expressed as an unsigned integer.  | be considered as|
+    |                                                           | of events the application     |                                    | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_RENDER_PASSES_COREAVI                      | This attribute specifies      | Maximum number of render pass      | 128 (might not  |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of render passes the          | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_PIPELINE_LAYOUTS_COREAVI                   | This attribute specifies      | Maximum number of pipeline layout  | 256 (might not  |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of pipeline layouts the       | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_GRAPHICS_PIPELINES_COREAVI                 | This attribute specifies      | Maximum number of graphics pipeline| 4096 (might not |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of graphics pipelines the     | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_FRAMEBUFFERS_COREAVI                       | This attribute specifies      | Maximum number of framebuffer      | 64 (might not   |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of framebuffers the           | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_COMMAND_POOLS_COREAVI                      | This attribute specifies      | Maximum number of command pool     | 32 (might not   |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of command pools the          | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_COMMAND_BUFFERS_COREAVI                    | This attribute specifies      | Maximum number of command buffer   | 128 (might not  |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of command buffers the        | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_SWAPCHAINS_KHR_COREAVI                     | This attribute specifies      | Maximum number of swapchain        | 16 (might not   |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of swapchains the application | integer.                           | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_RENDER_PASS_SUBPASSES_COREAVI              | This attribute specifies      | Maximum number of render pass      | 1024 (might not |
+    |                                                           | the maximum number            | subpass objects expressed as       | be considered as|
+    |                                                           | of render pass subpasses the  | an unsigned integer.               | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_RENDER_PASS_ATTACHMENTS_COREAVI            | This attribute specifies      | Maximum number of render pass      | 4096 (might not |
+    |                                                           | the maximum number            | attachemnt objects expressed as    | be considered as|
+    |                                                           | of render pass attachments    | an unsigned integer.               | valid by some   |
+    |                                                           | the application can create.   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_DESCRIPTOR_SETS_COREAVI                    | This attribute specifies      | Maximum number of descriptor set   | 128 (might not  |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of descriptor sets the        | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_DESCRIPTOR_SET_LAYOUTS_COREAVI             | This attribute specifies      | Maximum number of descriptor set   | 128 (might not  |
+    |                                                           | the maximum number            | layout objects expressed as an     | be considered as|
+    |                                                           | of descriptor set layouts     | unsigned integer.                  | valid by some   |
+    |                                                           | the application can create.   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_DESCRIPTOR_POOLS_COREAVI                   | This attribute specifies      | Maximum number of descriptor pool  | 32 (might not   |
+    |                                                           | the maximum number            | objects expressed as an unsigned   | be considered as|
+    |                                                           | of descriptor pools the       | integer.                           | valid by some   |
+    |                                                           | application can create.       |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_DESCRIPTOR_SET_LAYOUT_BINDINGS_COREAVI     | This attribute specifies      | Maximum number of descriptor set   | 4096 (might not |
+    |                                                           | the maximum number            | layout binding objects expressed   | be considered as|
+    |                                                           | of descriptor set layout      | as a unsigned integer.             | valid by some   |
+    |                                                           | bindings the application      |                                    | implementations)|
+    |                                                           | can create.                   |                                    |                 |
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_BUFFERS_COREAVI                            | This attribute specifies      | Maximum number of buffer objects   | 4096 (might not |
+    |                                                           | the maximum number            | expressed as an unsigned integer.  | be considered as|
+    |                                                           | of buffers the application    |                                    | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    |                                                           |                               |                                    |                 |
+    | EGL_DEVICE_MAX_SAMPLERS_COREAVI                           | This attribute specifies      | Maximum number of sampler objects  | 4096 (might not |
+    |                                                           | the maximum number            | expressed as an unsigned integer.  | be considered as|
+    |                                                           | of samplers the application   |                                    | valid by some   |
+    |                                                           | can create.                   |                                    | implementations)|
+    +-----------------------------------------------------------+-------------------------------+------------------------------------+-----------------+
+    Table 3.1. Legal attributes for eglInitializeDeviceEXT <attrib_list> parameter
+    
+    Applications can choose a specific GPU in a multi-GPU system by 
+    using the device ID attribute EGL_DEVICE_INIT_GPU_DEVICE_ID_COREAVI. The
+    value for this attribute is 0 based device id and should lie between 0 and
+    n-1 for a systems with n GPUs. Values outside this range will cause
+    the function eglInitializeDeviceEXT() to fail and return EGL_NO_DEVICE_EXT.
+    By default the first GPU is chosen. 
+    
+    Applications that require sharing memory between them can request 
+    use of shared memory regions by using the system attribute 
+    EGL_DEVICE_INIT_SHARED_MEMORY_COREAVI with a non-zero value. Use of these
+    shared memory regions is implementation specific. By default shared 
+    memory regions are not enabled. 
+    
+    Implementations that can uniquely initialize the device and system to
+    handle different application classes can do so using the pointer the 
+    application name passed as in as value to the system attribute 
+    EGL_DEVICE_INIT_APP_NAME_COREAVI. The value should point to a NULL
+    terminated string.
+
+    Applications can pass the underlying VkCore SC library a Direct Call
+    Interface so it can call the GPUManager APIs directly without the use
+    of a separate GPUManager application.
+
+    Implementations that use programmable shader pipelines require
+    that applications pass to the driver the following informations about
+    all the shader programs they will use during their lifetime:
+    the total number of shader programs, their binaries and their size.
+    Given these informations the driver will be able to assess the
+    resources that will be needed and prepare accordingly.
+    
+    Implementations that use the fixed-function graphics pipeline allow 
+    applications to set the maximum number of objects created for certain 
+    object types. Given this information the driver will be able to assess 
+    the total memory resources that will be needed and prepare accordingly. 
+    These maximums are originally set by defaults.
+    
+Errors
+
+    None 
+
+Sample Code
+
+   None
+
+Conformance Tests
+
+    None
+
+Issues
+
+    None
+
+Revision History
+    
+    Revision 0.3 2022/05/05
+        - Added _COREAVI suffix to system attributes.
+        - Added system attributes for object maximums.
+        - Fixed minor typos.
+    
+    Revision 0.2 2021/10/12
+        - Add new system attributes.
+        - Add device ID attribute.
+
+    Revision 0.1 2020/06/21
+        - Initial Draft


### PR DESCRIPTION
I created a new folder for these to be COREAVI specific extensions. I assumed this is what we wanted -- initially at least.
Please let me know if they should be submitted as EGL_EXT extensions instead.

My additions here to what we used to have in our repository were the attribute values that state creation maximums for specific maximums when in a fixed function graphics pipeline (SC1).
Another addition were the COREAVI suffix to the attribute names.

